### PR TITLE
Add logic to hide partner's tab, auto populate and suggest plot name and other UI fixes

### DIFF
--- a/managefarmspro/managefarmspro/doctype/cluster/cluster.json
+++ b/managefarmspro/managefarmspro/doctype/cluster/cluster.json
@@ -66,12 +66,13 @@
   {
    "fieldname": "supervisor",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Supervisor"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-01 12:10:01.710529",
+ "modified": "2024-09-03 13:43:42.841020",
  "modified_by": "Administrator",
  "module": "Managefarmspro",
  "name": "Cluster",

--- a/managefarmspro/managefarmspro/doctype/link_plot_cluster/link_plot_cluster.json
+++ b/managefarmspro/managefarmspro/doctype/link_plot_cluster/link_plot_cluster.json
@@ -16,6 +16,7 @@
   {
    "fieldname": "plot",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Plot",
    "link_filters": "[[\"Plot\",\"cluster_name\",\"=\",\"eval: parent.cluster_name\"]]",
    "options": "Plot"
@@ -30,7 +31,9 @@
    "fetch_from": "plot.area",
    "fieldname": "plot_area",
    "fieldtype": "Float",
-   "label": "Plot Area"
+   "in_list_view": 1,
+   "label": "Plot Area",
+   "precision": "2"
   },
   {
    "fieldname": "column_break_iyqd",
@@ -40,13 +43,14 @@
    "fetch_from": "plot.units",
    "fieldname": "units",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Unit(s)"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-01 10:14:01.337896",
+ "modified": "2024-09-03 15:18:42.114622",
  "modified_by": "Administrator",
  "module": "Managefarmspro",
  "name": "link plot cluster",

--- a/managefarmspro/managefarmspro/doctype/link_plot_owner/link_plot_owner.json
+++ b/managefarmspro/managefarmspro/doctype/link_plot_owner/link_plot_owner.json
@@ -8,12 +8,14 @@
  "field_order": [
   "plot",
   "plot_name",
-  "plot_area"
+  "plot_area",
+  "units"
  ],
  "fields": [
   {
    "fieldname": "plot",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Plot",
    "link_filters": "[[\"Plot\",\"full_name\",\"=\",\"eval: parent.full_name\"]]",
    "options": "Plot",
@@ -29,13 +31,21 @@
    "fetch_from": "plot.area",
    "fieldname": "plot_area",
    "fieldtype": "Float",
+   "in_list_view": 1,
    "label": "Plot Area"
+  },
+  {
+   "fetch_from": "plot.units",
+   "fieldname": "units",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Unit(s)"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-01 11:17:32.409222",
+ "modified": "2024-09-03 12:14:40.593125",
  "modified_by": "Administrator",
  "module": "Managefarmspro",
  "name": "link plot owner",

--- a/managefarmspro/managefarmspro/doctype/owner/owner.json
+++ b/managefarmspro/managefarmspro/doctype/owner/owner.json
@@ -4,10 +4,13 @@
  "allow_rename": 1,
  "autoname": "format:OW-{MM}-{YYYY}-{####}",
  "creation": "2024-08-28 17:54:55.958268",
+ "default_view": "List",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "owner_tab",
+  "section_break_bidr",
+  "full_name",
   "owner_information_section",
   "first_name",
   "phone_number",
@@ -22,8 +25,6 @@
   "ownership_details_section",
   "notes_remarks",
   "document_attachments",
-  "section_break_bidr",
-  "full_name",
   "partners_tab",
   "partners_information",
   "plot_tab",
@@ -91,6 +92,7 @@
   {
    "fieldname": "email",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Email"
   },
   {
@@ -128,6 +130,8 @@
   {
    "fieldname": "ownership_type",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Ownership Type",
    "options": "Individual\nCompany\nPartnership\nOthers"
   },
@@ -152,6 +156,7 @@
    "fieldtype": "Data",
    "hidden": 1,
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Full Name",
    "read_only": 1,
    "unique": 1
@@ -165,7 +170,7 @@
    "link_fieldname": "owner_name"
   }
  ],
- "modified": "2024-09-01 14:32:36.144073",
+ "modified": "2024-09-03 14:40:15.885330",
  "modified_by": "Administrator",
  "module": "Managefarmspro",
  "name": "Owner",
@@ -187,7 +192,7 @@
  ],
  "search_fields": "full_name",
  "show_title_field_in_link": 1,
- "sort_field": "modified",
+ "sort_field": "full_name",
  "sort_order": "DESC",
  "states": [],
  "title_field": "full_name"

--- a/managefarmspro/managefarmspro/doctype/partner/partner.json
+++ b/managefarmspro/managefarmspro/doctype/partner/partner.json
@@ -15,6 +15,7 @@
   {
    "fieldname": "phone_number",
    "fieldtype": "Phone",
+   "in_list_view": 1,
    "label": "Phone Number"
   },
   {
@@ -24,18 +25,20 @@
   {
    "fieldname": "email",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Email"
   },
   {
    "fieldname": "partner_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Partner Name"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-01 09:43:48.306973",
+ "modified": "2024-09-03 13:05:01.826876",
  "modified_by": "Administrator",
  "module": "Managefarmspro",
  "name": "Partner",

--- a/managefarmspro/managefarmspro/doctype/plot/plot.json
+++ b/managefarmspro/managefarmspro/doctype/plot/plot.json
@@ -103,9 +103,11 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "SF1",
    "fieldname": "plot_location",
-   "fieldtype": "Data",
-   "label": "Plot Location"
+   "fieldtype": "Select",
+   "label": "Plot Location",
+   "options": "SF1\nTBD\nNA"
   },
   {
    "fieldname": "section_break_nucz",
@@ -164,7 +166,7 @@
   {
    "fieldname": "inspection_history_section",
    "fieldtype": "Section Break",
-   "label": "inspection History"
+   "label": "Inspection History"
   },
   {
    "fieldname": "last_inspection_date",
@@ -227,7 +229,7 @@
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-01 10:02:47.060300",
+ "modified": "2024-09-03 14:50:14.552585",
  "modified_by": "Administrator",
  "module": "Managefarmspro",
  "name": "Plot",


### PR DESCRIPTION
Add logic to hide partner's tab in owner doctype wherever there is no partner, add logic to auto populate and suggest plot name according to the plot number, other minor UI fixes.